### PR TITLE
Add licences-api project

### DIFF
--- a/licences-api/mock/azure-devtest.tf
+++ b/licences-api/mock/azure-devtest.tf
@@ -1,0 +1,33 @@
+variable "azure_subscription_id" {
+    type = "string"
+    default = "c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"
+}
+variable "azure_tenant_id" {
+    type = "string"
+    default = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+}
+variable "azure_app_service_oid" {
+  type = "string"
+  default = "5b2509b1-64bd-4117-b839-9b0c2b02e02c"
+}
+variable "azure_webops_group_oid" {
+    type = "string"
+    default = "98dc3307-f515-4717-b3c1-7174413e20b0"
+}
+
+// These AD ObjectIDs were found via `az ad sp list`
+variable "azure_glenm_tf_oid" {
+    type = "string"
+    default = "3763b95f-5a74-4aa9-a596-2960bf7fb799"
+}
+variable "azure_robl_tf_oid" {
+    type = "string"
+    default = "ec0c3ab3-0a6e-4260-87c3-93935fe29b3e"
+}
+provider "azurerm" {
+    # NOMS Digital Studio Dev & Test Environments
+    subscription_id = "c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"
+    # client_id = "..." use ARM_CLIENT_ID env var
+    # client_secret = "..." use ARM_CLIENT_SECRET env var
+    tenant_id = "${var.azure_tenant_id}"
+}

--- a/licences-api/mock/github.tf
+++ b/licences-api/mock/github.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  # token = "..." use GITHUB_TOKEN env var
+  organization = "noms-digital-studio"
+}

--- a/licences-api/mock/main.tf
+++ b/licences-api/mock/main.tf
@@ -1,0 +1,264 @@
+terraform {
+    required_version = ">= 0.10.5"
+    backend "azurerm" {
+        resource_group_name = "webops"
+        storage_account_name = "nomsstudiowebops"
+        container_name = "terraform"
+        key = "licences-api-mock.terraform.tfstate"
+        arm_subscription_id = "c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"
+        arm_tenant_id = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+    }
+}
+
+variable "app-name" {
+    type = "string"
+    default = "licences-api-mock"
+}
+
+variable "tags" {
+    type = "map"
+    default {
+        Service = "Licences API"
+        Environment = "Mock"
+    }
+}
+
+resource "random_id" "session-secret" {
+    byte_length = 40
+}
+
+resource "random_id" "sql-app-password" {
+    byte_length = 32
+}
+
+resource "azurerm_resource_group" "group" {
+    name = "${var.app-name}"
+    location = "ukwest"
+    tags = "${var.tags}"
+}
+
+resource "azurerm_storage_account" "storage" {
+    name = "${replace(var.app-name, "-", "")}storage"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    location = "${azurerm_resource_group.group.location}"
+    account_type = "Standard_RAGRS"
+    enable_blob_encryption = true
+
+    tags = "${var.tags}"
+}
+
+resource "azurerm_storage_container" "logs" {
+    name = "web-logs"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    storage_account_name = "${azurerm_storage_account.storage.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_key_vault" "vault" {
+    name = "${var.app-name}"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    location = "${azurerm_resource_group.group.location}"
+    sku {
+        name = "standard"
+    }
+    tenant_id = "${var.azure_tenant_id}"
+
+    access_policy {
+        tenant_id = "${var.azure_tenant_id}"
+        object_id = "${var.azure_webops_group_oid}"
+        key_permissions = ["all"]
+        secret_permissions = ["all"]
+    }
+    access_policy {
+        tenant_id = "${var.azure_tenant_id}"
+        object_id = "${var.azure_app_service_oid}"
+        key_permissions = []
+        secret_permissions = ["get"]
+    }
+    access_policy {
+        object_id = "${var.azure_glenm_tf_oid}"
+        tenant_id = "${var.azure_tenant_id}"
+        key_permissions = []
+        secret_permissions = ["get", "set"]
+    }
+    access_policy {
+        object_id = "${var.azure_robl_tf_oid}"
+        tenant_id = "${var.azure_tenant_id}"
+        key_permissions = []
+        secret_permissions = ["get", "set"]
+    }
+
+    enabled_for_deployment = false
+    enabled_for_disk_encryption = false
+    enabled_for_template_deployment = true
+
+    tags = "${var.tags}"
+}
+
+module "sql" {
+    source = "../../shared/modules/azure-sql"
+    name = "${var.app-name}"
+    resource_group = "${azurerm_resource_group.group.name}"
+    location = "${azurerm_resource_group.group.location}"
+    administrator_login = "licences-api"
+    firewall_rules = [
+        {
+            label = "Open to the world"
+            start = "0.0.0.0"
+            end = "255.255.255.255"
+        },
+    ]
+    audit_storage_account = "${azurerm_storage_account.storage.name}"
+    edition = "Basic"
+    collation = "SQL_Latin1_General_CP1_CI_AS"
+    tags = "${var.tags}"
+
+    db_users = {
+        app = "${random_id.sql-app-password.b64}"
+    }
+
+    setup_queries = [
+        "ALTER ROLE db_datareader ADD MEMBER app",
+        "ALTER ROLE db_datawriter ADD MEMBER app"
+    ]
+}
+
+resource "azurerm_template_deployment" "webapp" {
+    name = "webapp"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../../shared/appservice.template.json")}"
+    parameters {
+        name = "${var.app-name}"
+        service = "${var.tags["Service"]}"
+        environment = "${var.tags["Environment"]}"
+        workers = "1"
+        sku_name = "S1"
+        sku_tier = "Standard"
+    }
+}
+
+data "external" "sas-url" {
+    program = ["node", "../../tools/container-sas-url.js"]
+    query {
+        subscription_id = "${var.azure_subscription_id}"
+        tenant_id = "${var.azure_tenant_id}"
+        resource_group = "${azurerm_resource_group.group.name}"
+        storage_account = "${azurerm_storage_account.storage.name}"
+        container = "web-logs"
+        permissions = "rwdl"
+        start_date = "2017-05-15T00:00:00Z"
+        end_date = "2217-05-15T00:00:00Z"
+    }
+}
+
+resource "azurerm_template_deployment" "webapp-weblogs" {
+    name = "webapp-weblogs"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../../shared/appservice-weblogs.template.json")}"
+
+    parameters {
+        name = "${var.app-name}"
+        storageSAS = "${data.external.sas-url.result["url"]}"
+    }
+
+    depends_on = ["azurerm_template_deployment.webapp"]
+}
+
+resource "azurerm_template_deployment" "insights" {
+    name = "${var.app-name}"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../../shared/insights.template.json")}"
+    parameters {
+        name = "${var.app-name}"
+        location = "northeurope" // Not in UK yet
+        service = "${var.tags["Service"]}"
+        environment = "${var.tags["Environment"]}"
+        appServiceId = "${azurerm_template_deployment.webapp.outputs["resourceId"]}"
+    }
+}
+
+resource "azurerm_template_deployment" "webapp-config" {
+    name = "webapp-config"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../webapp-config.template.json")}"
+
+    parameters {
+        name = "${var.app-name}"
+        NODE_ENV = "production"
+        SESSION_SECRET = "${random_id.session-secret.b64}"
+        APPINSIGHTS_INSTRUMENTATIONKEY = "${azurerm_template_deployment.insights.outputs["instrumentationKey"]}"
+        DB_USER = "app"
+        DB_PASS = "${random_id.sql-app-password.b64}"
+        DB_SERVER = "${module.sql.db_server}"
+        DB_NAME = "${module.sql.db_name}"
+        NOMIS_API_URL = "https://licences-api-mocks.herokuapp.com/"
+    }
+
+    depends_on = ["azurerm_template_deployment.webapp"]
+}
+
+resource "azurerm_template_deployment" "webapp-ssl" {
+    name = "webapp-ssl"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../../shared/appservice-ssl.template.json")}"
+
+    parameters {
+        name = "${azurerm_template_deployment.webapp.parameters.name}"
+        hostname = "${azurerm_dns_cname_record.cname.name}.${azurerm_dns_cname_record.cname.zone_name}"
+        keyVaultId = "${azurerm_key_vault.vault.id}"
+        keyVaultCertName = "${replace("${azurerm_dns_cname_record.cname.name}.${azurerm_dns_cname_record.cname.zone_name}", ".", "DOT")}"
+        service = "${var.tags["Service"]}"
+        environment = "${var.tags["Environment"]}"
+    }
+
+    depends_on = ["azurerm_template_deployment.webapp"]
+}
+
+resource "azurerm_template_deployment" "webapp-github" {
+    name = "webapp-github"
+    resource_group_name = "${azurerm_resource_group.group.name}"
+    deployment_mode = "Incremental"
+    template_body = "${file("../../shared/appservice-scm.template.json")}"
+
+    parameters {
+        name = "${var.app-name}"
+        repoURL = "https://github.com/noms-digital-studio/licences-api"
+        branch = "deploy-to-mock"
+    }
+
+    depends_on = ["azurerm_template_deployment.webapp"]
+}
+
+resource "github_repository_webhook" "webapp-deploy" {
+  repository = "licences-api"
+
+  name = "web"
+  configuration {
+    url = "${azurerm_template_deployment.webapp-github.outputs["deployTrigger"]}?scmType=GitHub"
+    content_type = "form"
+    insecure_ssl = false
+  }
+  active = true
+
+  events = ["push"]
+}
+
+module "slackhook" {
+    source = "../../shared/modules/slackhook"
+    app_name = "${azurerm_template_deployment.webapp.parameters.name}"
+    channels = ["licences-dev"]
+}
+
+resource "azurerm_dns_cname_record" "cname" {
+    name = "licences-api-mock"
+    zone_name = "hmpps.dsd.io"
+    resource_group_name = "webops"
+    ttl = "300"
+    record = "${var.app-name}.azurewebsites.net"
+    tags = "${var.tags}"
+}

--- a/licences-api/webapp-config.template.json
+++ b/licences-api/webapp-config.template.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "type": "string"
+        },
+        "DB_SERVER": {
+            "type": "string"
+        },
+        "DB_USER": {
+            "type": "string"
+        },
+        "DB_PASS": {
+            "type": "secureString"
+        },
+        "DB_NAME": {
+            "type": "string"
+        },
+        "NODE_ENV": {
+            "type": "string"
+        },
+        "SESSION_SECRET": {
+            "type": "string"
+        },
+        "APPINSIGHTS_INSTRUMENTATIONKEY": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "NOMIS_API_URL": {
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('name'), '/appsettings')]",
+            "type": "Microsoft.Web/sites/config",
+            "properties": {
+                "WEBSITE_NODE_DEFAULT_VERSION": "8.4.0",
+                "DB_SERVER": "[parameters('DB_SERVER')]",
+                "DB_USER": "[parameters('DB_USER')]",
+                "DB_PASS": "[parameters('DB_PASS')]",
+                "DB_NAME": "[parameters('DB_NAME')]",
+                "NODE_ENV": "[parameters('NODE_ENV')]",
+                "SESSION_SECRET": "[parameters('SESSION_SECRET')]",
+                "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('APPINSIGHTS_INSTRUMENTATIONKEY')]",
+                "NOMIS_API_URL": "[parameters('NOMIS_API_URL')]"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
After architecture discussions today it seems we are going to have a much thinner UI project and a separate API project. The API project, licences-api, will wrap nomis and delius access and expose a tailored API to the licences UI project. Both UI and API projects are going to need a DB (at least that's how it looks for starters).

I've added licences-api by copying licences and changing the name here and there.