### PR TITLE
CSRA-680: Use STAGE Elite 2 API for CSRA STAGE

### DIFF
--- a/csra/stage/csra.tf
+++ b/csra/stage/csra.tf
@@ -208,7 +208,7 @@ resource "azurerm_template_deployment" "webapp-config" {
         DB_URI = "mssql://app:${random_id.sql-app-password.b64}@${module.sql.db_server}:1433/${module.sql.db_name}?encrypt=true"
         VIPER_SERVICE_URL = "https://aap-dev.hmpps.dsd.io/"
         VIPER_SERVICE_API_KEY = "${data.external.vault.result["viper_service_api_key"]}"
-        ELITE2_URL = "https://noms-api-dev.dsd.io/elite2api/"
+        ELITE2_URL = "https://noms-api-dev.dsd.io/elite2api-stage/"
         ELITE2_API_GATEWAY_TOKEN = "${data.external.vault.result.elite_api_gateway_token}"
         ELITE2_API_GATEWAY_PRIVATE_KEY = "${data.external.vault.result.elite_api_gateway_private_key}"
     }


### PR DESCRIPTION
We need to give you a new key and MoJ token because the old ones don't work with STAGE because the token has the wrong access string:

"access": [
    "^\\/elite2api\\/.*"
  ]

This causes a 403 error "Requested path does not match grants"

It should be:

"access": [
    ".*"
  ]
}