### PR TITLE
A couple of minor network tweaks for omic ui

### DIFF
--- a/omic-ui/dev/network.tf
+++ b/omic-ui/dev/network.tf
@@ -1,32 +1,44 @@
 resource "aws_vpc" "vpc" {
-    cidr_block = "192.168.0.0/26"
-    instance_tenancy = "default"
-    enable_dns_support = true
-    enable_dns_hostnames = false
-    tags = "${merge(var.tags, map("Name", var.app-name))}"
+  cidr_block                       = "192.168.0.0/26"
+  instance_tenancy                 = "default"
+  enable_dns_support               = true
+  enable_dns_hostnames             = false
+  assign_generated_ipv6_cidr_block = true
+  tags                             = "${merge(var.tags, map("Name", var.app-name))}"
 }
+
 resource "aws_subnet" "public-a" {
-  vpc_id     = "${aws_vpc.vpc.id}"
-  cidr_block = "192.168.0.0/28"
+  vpc_id            = "${aws_vpc.vpc.id}"
+  cidr_block        = "192.168.0.0/28"
   availability_zone = "${var.aws_az_a}"
-  tags = "${merge(var.tags, map("Name", "${var.app-name}-public-a"))}"
+  tags              = "${merge(var.tags, map("Name", "${var.app-name}-public-a"))}"
 }
 
 resource "aws_subnet" "private-a" {
-  vpc_id     = "${aws_vpc.vpc.id}"
-  cidr_block = "192.168.0.32/28"
+  vpc_id            = "${aws_vpc.vpc.id}"
+  cidr_block        = "192.168.0.32/28"
   availability_zone = "${var.aws_az_a}"
-  tags = "${merge(var.tags, map("Name", "${var.app-name}-private-a"))}"
+  tags              = "${merge(var.tags, map("Name", "${var.app-name}-private-a"))}"
 }
 
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.vpc.id}"
-  tags = "${merge(var.tags, map("Name", var.app-name))}"
+  tags   = "${merge(var.tags, map("Name", var.app-name))}"
+}
+
+resource "aws_eip" "nat" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "gw" {
+  allocation_id = "${aws_eip.nat.id}"
+  subnet_id     = "${aws_subnet.public-a.id}"
+  depends_on    = ["aws_internet_gateway.gw"]
 }
 
 resource "aws_default_route_table" "default" {
   default_route_table_id = "${aws_vpc.vpc.default_route_table_id}"
-  tags = "${merge(var.tags, map("Name", var.app-name))}"
+  tags                   = "${merge(var.tags, map("Name", var.app-name))}"
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -34,24 +46,19 @@ resource "aws_default_route_table" "default" {
   }
 }
 
-resource "aws_eip" "nat" {
-  vpc = true
-}
-resource "aws_nat_gateway" "gw" {
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id     = "${aws_subnet.public-a.id}"
-  depends_on = ["aws_internet_gateway.gw"]
-}
-
-
 resource "aws_route_table" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
-  tags = "${merge(var.tags, map("Name", "${var.app-name}-private"))}"
+  tags   = "${merge(var.tags, map("Name", "${var.app-name}-private"))}"
 
   route {
-    cidr_block = "0.0.0.0/0"
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = "${aws_nat_gateway.gw.id}"
   }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = "${aws_subnet.public-a.id}"
+  route_table_id = "${aws_default_route_table.default.id}"
 }
 
 resource "aws_route_table_association" "private" {


### PR DESCRIPTION
My editor ran `terraform fmt`, add `?w=1` to the URL for a decent diff.

Added IPv6 because I was trying to get an egress-only gateway to work, but gave up on this.

Made the public subnet route table association explicit, rather than implicit