### PR TITLE
add long timeout for prod

### DIFF
--- a/keyworker-api/dev/main.tf
+++ b/keyworker-api/dev/main.tf
@@ -278,7 +278,7 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SERVER_CONNECTION_TIMEOUT"
-    value     = "180000"
+    value     = "${local.server_timeout}"
   }
   tags = "${var.tags}"
 }

--- a/keyworker-api/dev/main.tf
+++ b/keyworker-api/dev/main.tf
@@ -275,6 +275,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
     name      = "ELITE2API_CLIENT_CLIENTSECRET"
     value     = "${data.aws_ssm_parameter.omic-admin-secret.value}"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SERVER_CONNECTION_TIMEOUT"
+    value     = "180000"
+  }
   tags = "${var.tags}"
 }
 

--- a/keyworker-api/dev/vars.tf
+++ b/keyworker-api/dev/vars.tf
@@ -15,4 +15,5 @@ variable "tags" {
 locals {
   elite2_uri_root = "https://noms-api-dev.dsd.io/elite2api"
   omic_clientid = "omicadmin"
+  server_timeout = "60000"
 }

--- a/keyworker-api/preprod/main.tf
+++ b/keyworker-api/preprod/main.tf
@@ -278,7 +278,7 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SERVER_CONNECTION_TIMEOUT"
-    value     = "180000"
+    value     = "${local.server_timeout}"
   }
   tags = "${var.tags}"
 }

--- a/keyworker-api/preprod/main.tf
+++ b/keyworker-api/preprod/main.tf
@@ -275,6 +275,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
     name      = "ELITE2API_CLIENT_CLIENTSECRET"
     value     = "${data.aws_ssm_parameter.omic-admin-secret.value}"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SERVER_CONNECTION_TIMEOUT"
+    value     = "180000"
+  }
   tags = "${var.tags}"
 }
 

--- a/keyworker-api/preprod/vars.tf
+++ b/keyworker-api/preprod/vars.tf
@@ -15,4 +15,5 @@ variable "tags" {
 locals {
   elite2_uri_root  = "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/elite2api"
   omic_clientid = "omicadmin"
+  server_timeout = "240000"
 }

--- a/keyworker-api/prod/main.tf
+++ b/keyworker-api/prod/main.tf
@@ -278,7 +278,7 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SERVER_CONNECTION_TIMEOUT"
-    value     = "180000"
+    value     = "${local.server_timeout}"
   }
   tags = "${var.tags}"
 }

--- a/keyworker-api/prod/main.tf
+++ b/keyworker-api/prod/main.tf
@@ -275,6 +275,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
     name      = "ELITE2API_CLIENT_CLIENTSECRET"
     value     = "${data.aws_ssm_parameter.omic-admin-secret.value}"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SERVER_CONNECTION_TIMEOUT"
+    value     = "180000"
+  }
   tags = "${var.tags}"
 }
 

--- a/keyworker-api/prod/vars.tf
+++ b/keyworker-api/prod/vars.tf
@@ -15,4 +15,5 @@ variable "tags" {
 locals {
   elite2_uri_root = "https://gateway.nomis-api.service.justice.gov.uk/elite2api"
   omic_clientid = "omicadmin"
+  server_timeout = "180000"
 }

--- a/keyworker-api/stage/main.tf
+++ b/keyworker-api/stage/main.tf
@@ -278,7 +278,7 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SERVER_CONNECTION_TIMEOUT"
-    value     = "180000"
+    value     = "${local.server_timeout}"
   }
   tags = "${var.tags}"
 }

--- a/keyworker-api/stage/main.tf
+++ b/keyworker-api/stage/main.tf
@@ -275,6 +275,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
     name      = "ELITE2API_CLIENT_CLIENTSECRET"
     value     = "${data.aws_ssm_parameter.omic-admin-secret.value}"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SERVER_CONNECTION_TIMEOUT"
+    value     = "180000"
+  }
   tags = "${var.tags}"
 }
 

--- a/keyworker-api/stage/vars.tf
+++ b/keyworker-api/stage/vars.tf
@@ -15,4 +15,5 @@ variable "tags" {
 locals {
   elite2_uri_root = "https://gateway.t2.nomis-api.hmpps.dsd.io/elite2api"
   omic_clientid = "omicadmin"
+  server_timeout = "180000"
 }


### PR DESCRIPTION
Needed for migration curl call as this can take longer than 1 minute in production, we could ASYNC it but as its temporary, it might not be worth it.