### PR TITLE
NN-1200: First stab at splitting elite2api / oauth urls for licences

### DIFF
--- a/licences/mock/main.tf
+++ b/licences/mock/main.tf
@@ -357,6 +357,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "NOMIS_AUTH_URL"
+    value     = "${local.nomis_auth_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "PDF_SERVICE_HOST"
     value     = "${local.pdf_service_host}"
   }

--- a/licences/mock/vars.tf
+++ b/licences/mock/vars.tf
@@ -21,6 +21,7 @@ locals {
 # App settings
 locals {
   nomis_api_url       = "https://licences-nomis-mocks.herokuapp.com/elite2api"
+  nomis_auth_url      = "https://licences-nomis-mocks.herokuapp.com/elite2api"
   api_client_id       = "licences"
   pdf_service_host    = "https://licences-nomis-mocks.herokuapp.com"
 }

--- a/licences/preprod/main.tf
+++ b/licences/preprod/main.tf
@@ -299,6 +299,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "NOMIS_AUTH_URL"
+    value     = "${local.nomis_auth_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "PDF_SERVICE_HOST"
     value     = "http://${aws_elastic_beanstalk_environment.pdf-gen-app-env.cname}"
   }

--- a/licences/preprod/vars.tf
+++ b/licences/preprod/vars.tf
@@ -40,6 +40,7 @@ locals {
 # App settings
 locals {
   nomis_api_url       = "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/elite2api/api"
+  nomis_auth_url      = "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/elite2api"
   api_client_id       = "licences"
 }
 

--- a/licences/stage/main.tf
+++ b/licences/stage/main.tf
@@ -299,6 +299,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "NOMIS_AUTH_URL"
+    value     = "${local.nomis_auth_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "PDF_SERVICE_HOST"
     value     = "http://${aws_elastic_beanstalk_environment.pdf-gen-app-env.cname}"
   }

--- a/licences/stage/vars.tf
+++ b/licences/stage/vars.tf
@@ -40,6 +40,7 @@ locals {
 # App settings
 locals {
   nomis_api_url       = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api"
+  nomis_auth_url      = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api"
   api_client_id       = "licences"
 }
 

--- a/nomis-batchload/preprod/main.tf
+++ b/nomis-batchload/preprod/main.tf
@@ -299,6 +299,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "NOMIS_AUTH_URL"
+    value     = "${local.nomis_auth_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "BATCH_USER_ROLE"
     value     = "NOMIS_BATCHLOAD"
   }

--- a/nomis-batchload/preprod/vars.tf
+++ b/nomis-batchload/preprod/vars.tf
@@ -25,6 +25,7 @@ locals {
 # App settings
 locals {
   nomis_api_url       = "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/elite2api/api"
+  nomis_auth_url      = "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/elite2api"
   api_client_id       = "batchadmin"
 }
 

--- a/nomis-batchload/stage/main.tf
+++ b/nomis-batchload/stage/main.tf
@@ -346,6 +346,11 @@ resource "aws_elastic_beanstalk_environment" "app-env" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "NOMIS_AUTH_URL"
+    value     = "${local.nomis_auth_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "BATCH_USER_ROLE"
     value     = "NOMIS_BATCHLOAD"
   }

--- a/nomis-batchload/stage/vars.tf
+++ b/nomis-batchload/stage/vars.tf
@@ -25,6 +25,7 @@ locals {
 # App settings
 locals {
   nomis_api_url       = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api"
+  nomis_auth_url      = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api"
   api_client_id       = "batchadmin"
 }
 


### PR DESCRIPTION
Currently just setting the `AUTH_URL` to be the licences url so nginx still needs to do the translation...