### PR TITLE
Added permissions for ansible monorepo prod

### DIFF
--- a/webops/dev/versions.tf
+++ b/webops/dev/versions.tf
@@ -1,14 +1,19 @@
 terraform {
   required_providers {
     azurerm = {
-      version = ">= 2.48.0"
       source  = "hashicorp/azurerm"
+      version = ">= 2.48.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "1.4.0"
+    }
+
   }
   required_version = ">= 0.14"
 }
 provider "azurerm" {
   tenant_id       = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
-  subscription_id = "c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"
+  subscription_id = "a5ddf257-3b21-4ba9-a28c-ab30f751b383"
   features {}
 }

--- a/webops/dev/versions.tf
+++ b/webops/dev/versions.tf
@@ -1,10 +1,9 @@
 terraform {
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
       version = ">= 2.48.0"
+      source  = "hashicorp/azurerm"
     }
-
   }
   required_version = ">= 0.14"
 }

--- a/webops/dev/versions.tf
+++ b/webops/dev/versions.tf
@@ -4,16 +4,12 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 2.48.0"
     }
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "1.4.0"
-    }
 
   }
   required_version = ">= 0.14"
 }
 provider "azurerm" {
   tenant_id       = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
-  subscription_id = "a5ddf257-3b21-4ba9-a28c-ab30f751b383"
+  subscription_id = "c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"
   features {}
 }

--- a/webops/prod/.terraform.lock.hcl
+++ b/webops/prod/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "1.4.0"
+  constraints = "1.4.0"
+  hashes = [
+    "h1:/zBp78avkj22m4qGF1DpKunBQJwHJCVbQTfBsvCrA40=",
+    "zh:07aa14f0925bf0486f8cb8ee33fecc466ea3446d95aef33db598b01d2198dcb9",
+    "zh:0ce1b196d11a507ced54a0641db4112a0e0b6bd85d756a768b146dff630a9661",
+    "zh:166a705b58d25f133ccc35ae601b41a1322c8a78f3a58f2ef5082b16dc56f46e",
+    "zh:1c098e4eb420a98ac541d1a68a534f848f2b19125605fd6ed3bbdbf877d748c6",
+    "zh:326cffab3b598f70b55a470b6cc3ccea417c71523066c1712bf5ac07f21aded7",
+    "zh:4cf651bb26faf96db37ef91d44c251ecc0034a964d695d16a91f24d752805f96",
+    "zh:4f508b7ab711026f7a876625695938c82265d8d5a11bf421e7c8e6c9a541cdd5",
+    "zh:5cdde77636310bf5fc2cb9fdcde0102e7c3689f0c75326a66f128eaf5d02d2f3",
+    "zh:748261e8370370db5ab1f3d9b8d5b050799e07a94f1dafe4bc6721cae04ca15d",
+    "zh:c8f90ec99708e7c8bb9fb8c09b1a816c7370435271895ff142d7f2f8d8d81951",
+    "zh:eb53d13fe64b14b322ac17eee842bd9ef338c178f902700a9033238b2aa95044",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.48.0"
   constraints = ">= 2.48.0"

--- a/webops/prod/jenkins-keyvault.tf
+++ b/webops/prod/jenkins-keyvault.tf
@@ -1,3 +1,11 @@
+data "azuread_service_principal" "ansible_monorepo_prod" {
+  display_name = "ansible-monorepo-prod"
+}
+
+
+data "azuread_service_principal" "dso_certificates" {
+  display_name = "dso-certificates"
+}
 
 resource "azurerm_key_vault" "webops_jenkins" {
   name                     = "webops-jenkins-prod"
@@ -37,7 +45,14 @@ resource "azurerm_key_vault" "webops_jenkins" {
 
   access_policy {
     tenant_id          = var.azure_tenant_id
-    object_id          = var.dso_certificates_oid
+    object_id          = data.azuread_service_principal.dso_certificates.object_id
+    key_permissions    = []
+    secret_permissions = ["get"]
+  }
+
+  access_policy {
+    tenant_id          = var.azure_tenant_id
+    object_id          = data.azuread_service_principal.ansible_monorepo_prod.object_id
     key_permissions    = []
     secret_permissions = ["get"]
   }

--- a/webops/prod/versions.tf
+++ b/webops/prod/versions.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 2.48.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "1.4.0"
+    }
+
   }
   required_version = ">= 0.14"
 }


### PR DESCRIPTION
Plan output

# azurerm_key_vault.webops_jenkins will be updated in-place
  ~ resource "azurerm_key_vault" "webops_jenkins" {
      ~ access_policy                   = [
            # (4 unchanged elements hidden)
            {
                application_id          = ""
                certificate_permissions = []
                key_permissions         = []
                object_id               = "a3415938-d0a1-4cfe-b312-edf87c251a69"
                secret_permissions      = [
                    "Get",
                ]
                storage_permissions     = []
                tenant_id               = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
            },
          + {
              + application_id          = null
              + certificate_permissions = null
              + key_permissions         = []
              + object_id               = "4a65e4b7-189c-4d87-980a-050b9969009d"
              + secret_permissions      = [
                  + "get",
                ]
              + storage_permissions     = null
              + tenant_id               = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
            },
        ]
        id                              = "/subscriptions/a5ddf257-3b21-4ba9-a28c-ab30f751b383/resourceGroups/webops-prod/providers/Microsoft.KeyVault/vaults/webops-jenkins-prod"
        name                            = "webops-jenkins-prod"
      ~ purge_protection_enabled        = false -> true
        tags                            = {
            "application"      = "Management"
            "environment_name" = "prod"
            "service"          = "FixNGo"
        }
        # (11 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.