### PR TITLE
Added a data source to pass into the app service module

### DIFF
--- a/offloc/prod/main.tf
+++ b/offloc/prod/main.tf
@@ -16,7 +16,7 @@ module "app_service" {
   ssl_state                = "IpBasedEnabled"
   app_service_plan_size    = var.app_service_plan_size
   scm_type                 = "LocalGit"
-  certificate_kv_secret_id = data.azurerm_key_vault_secret.webapp_ssl_secret_id
+  certificate_kv_secret_id = data.azurerm_key_vault_secret.webapp_ssl_secret_id.id
   app_settings = {
     "AZURE_STORAGE_ACCOUNT_NAME"    = "offlocprodapp"
     "AZURE_STORAGE_CONTAINER_NAME"  = "cde"
@@ -91,5 +91,5 @@ resource "azurerm_key_vault" "app" {
 
 data "azurerm_key_vault_secret" "webapp_ssl_secret_id" {
   name         = "CERTwwwDOTofflocDOTserviceDOTjusticeDOTgovDOTuk"
-  key_vault_id = "https://offloc-prod.vault.azure.net/"
+  key_vault_id = module.app_service.vault_id
 }

--- a/offloc/prod/main.tf
+++ b/offloc/prod/main.tf
@@ -91,5 +91,5 @@ resource "azurerm_key_vault" "app" {
 
 data "azurerm_key_vault_secret" "webapp_ssl_secret_id" {
   name         = "CERTwwwDOTofflocDOTserviceDOTjusticeDOTgovDOTuk"
-  key_vault_id = azurerm_key_vault.app.id
+  key_vault_id = "https://offloc-prod.vault.azure.net/"
 }

--- a/offloc/prod/main.tf
+++ b/offloc/prod/main.tf
@@ -16,6 +16,7 @@ module "app_service" {
   ssl_state                = "IpBasedEnabled"
   app_service_plan_size    = var.app_service_plan_size
   scm_type                 = "LocalGit"
+  certificate_kv_secret_id = data.azurerm_key_vault_secret.webapp_ssl_secret_id
   app_settings = {
     "AZURE_STORAGE_ACCOUNT_NAME"    = "offlocprodapp"
     "AZURE_STORAGE_CONTAINER_NAME"  = "cde"
@@ -86,4 +87,9 @@ resource "azurerm_key_vault" "app" {
   enabled_for_disk_encryption     = false
   enabled_for_template_deployment = false
   tags                            = var.tags
+}
+
+data "azurerm_key_vault_secret" "webapp_ssl_secret_id" {
+  name         = "CERTwwwDOTofflocDOTserviceDOTjusticeDOTgovDOTuk"
+  key_vault_id = azurerm_key_vault.app.id
 }

--- a/shared/modules/azure-app-service/main.tf
+++ b/shared/modules/azure-app-service/main.tf
@@ -150,7 +150,6 @@ resource "azurerm_app_service_certificate" "webapp-ssl" {
   resource_group_name = azurerm_resource_group.group.name
   location            = azurerm_resource_group.group.location
   tags                = var.tags
-  #When you need to re-create add the key vault secret key id in, comment after so it doesn't get in the way of the plan or you'll need to main after every cert refresh
   key_vault_secret_id = var.certificate_kv_secret_id
 }
 

--- a/shared/modules/azure-app-service/main.tf
+++ b/shared/modules/azure-app-service/main.tf
@@ -151,6 +151,13 @@ resource "azurerm_app_service_certificate" "webapp-ssl" {
   location            = azurerm_resource_group.group.location
   tags                = var.tags
   key_vault_secret_id = var.certificate_kv_secret_id
+
+  lifecycle {
+    ignore_changes = [
+      key_vault_secret_id,
+    ]
+  }
+
 }
 
 resource "azurerm_app_service_certificate_binding" "binding" {

--- a/shared/modules/azure-app-service/variables.tf
+++ b/shared/modules/azure-app-service/variables.tf
@@ -11,12 +11,13 @@ locals {
 
   github_deploy_branch = "deploy-to-${var.env}"
 }
-#When you need to re-create add the key vault secret key id in, comment after so it doesn't get in the way of the plan or you'll need to main after every cert refresh
+
 variable "certificate_kv_secret_id" {
   type        = string
   default     = null
   description = "Used to bind a certificate to the app"
 }
+
 variable "key_vault_secrets" {
   type    = list(string)
   default = []


### PR DESCRIPTION
There are three tags (which have nothing to do with me) that need to be applied to an app service certificate resource. `terraform apply` is failing due to a missing key vault secret id. The new data source should resolve this.

`terraform plan` from _offloc/prod_:

```terraform
Terraform will perform the following actions:

  # module.app_service.azurerm_app_service_certificate.webapp-ssl will be updated in-place
  ~ resource "azurerm_app_service_certificate" "webapp-ssl" {
        id                  = "/subscriptions/a5ddf257-3b21-4ba9-a28c-ab30f751b383/resourceGroups/offloc-prod/providers/Microsoft.Web/certificates/offloc-prod-offloc-prod-CERTwwwDOTofflocDOTserviceDOTjusticeDOTgovDOTuk"
        name                = "offloc-prod-offloc-prod-CERTwwwDOTofflocDOTserviceDOTjusticeDOTgovDOTuk"
      ~ tags                = {
          + "application"      = "NonCore"
          + "environment_name" = "prod"
          + "service"          = "NonCore"
        }
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```