### PR TITLE
Moved DNS zone help-with-prison-visits.service.gov.uk into Terraform management

### DIFF
--- a/webops/prod/dns-apvs.tf
+++ b/webops/prod/dns-apvs.tf
@@ -50,3 +50,16 @@ resource "azurerm_dns_ns_record" "apvs_zone_ns_record" {
   ttl                 = "172800"
   zone_name           = azurerm_dns_zone.help_with_prison_visits.name
 }
+
+resource "azurerm_dns_txt_record" "apvs_acme_challenge" {
+  provider = azurerm.apvs
+  name     = "_acme-challenge"
+
+  record {
+    value = "IB3suKjtigmB8tOSQNMJlDRnLm3eR9xJfNHA-NogkrE"
+  }
+
+  resource_group_name = "apvs-prd"
+  ttl                 = "10"
+  zone_name           = azurerm_dns_zone.help_with_prison_visits.name
+}

--- a/webops/prod/dns-apvs.tf
+++ b/webops/prod/dns-apvs.tf
@@ -14,3 +14,12 @@ resource "azurerm_dns_zone" "help_with_prison_visits" {
     ttl           = "3600"
   }
 }
+
+resource "azurerm_dns_a_record" "hwpv_zone_a_record" {
+  provider            = azurerm.apvs
+  name                = "@"
+  records             = ["51.140.33.178"]
+  resource_group_name = "apvs-prd"
+  ttl                 = "3600"
+  zone_name           = azurerm_dns_zone.help_with_prison_visits.name
+}

--- a/webops/prod/dns-apvs.tf
+++ b/webops/prod/dns-apvs.tf
@@ -41,3 +41,12 @@ resource "azurerm_dns_cname_record" "apvs_caseworker" {
   ttl                 = "3600"
   zone_name           = azurerm_dns_zone.help_with_prison_visits.name
 }
+
+resource "azurerm_dns_ns_record" "apvs_zone_ns_record" {
+  provider            = azurerm.apvs
+  name                = "@"
+  records             = ["ns1-01.azure-dns.com.", "ns2-01.azure-dns.net.", "ns3-01.azure-dns.org.", "ns4-01.azure-dns.info."]
+  resource_group_name = "apvs-prd"
+  ttl                 = "172800"
+  zone_name           = azurerm_dns_zone.help_with_prison_visits.name
+}

--- a/webops/prod/dns-apvs.tf
+++ b/webops/prod/dns-apvs.tf
@@ -1,0 +1,16 @@
+resource "azurerm_dns_zone" "help_with_prison_visits" {
+  provider            = azurerm.apvs
+  name                = "help-with-prison-visits.service.gov.uk"
+  resource_group_name = "apvs-prd"
+
+  soa_record {
+    email         = "azuredns-hostmaster.microsoft.com"
+    expire_time   = "2419200"
+    host_name     = "ns1-01.azure-dns.com."
+    minimum_ttl   = "300"
+    refresh_time  = "3600"
+    retry_time    = "300"
+    serial_number = "1"
+    ttl           = "3600"
+  }
+}

--- a/webops/prod/dns-apvs.tf
+++ b/webops/prod/dns-apvs.tf
@@ -23,3 +23,21 @@ resource "azurerm_dns_a_record" "hwpv_zone_a_record" {
   ttl                 = "3600"
   zone_name           = azurerm_dns_zone.help_with_prison_visits.name
 }
+
+resource "azurerm_dns_cname_record" "apvs_hash_like_cname" {
+  provider            = azurerm.apvs
+  name                = "_2a3b27e3fa8e6bd6d4ef293959a61090"
+  record              = "F736B151242EB8C7157E075B583488FC.92432E487F3EE5E8F539715731ED6B6D.b856bd4b563970cc9920.comodoca.com."
+  resource_group_name = "apvs-prd"
+  ttl                 = "3600"
+  zone_name           = azurerm_dns_zone.help_with_prison_visits.name
+}
+
+resource "azurerm_dns_cname_record" "apvs_caseworker" {
+  provider            = azurerm.apvs
+  name                = "caseworker"
+  record              = "e0e8c2cb-80cc-4087-a192-3b8fb4b49b2a.cloudapp.net"
+  resource_group_name = "apvs-prd"
+  ttl                 = "3600"
+  zone_name           = azurerm_dns_zone.help_with_prison_visits.name
+}

--- a/webops/prod/versions.tf
+++ b/webops/prod/versions.tf
@@ -14,6 +14,13 @@ terraform {
 }
 provider "azurerm" {
   tenant_id       = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
-  subscription_id = "a5ddf257-3b21-4ba9-a28c-ab30f751b383"
+  subscription_id = "a5ddf257-3b21-4ba9-a28c-ab30f751b383" # NOMS Digital Studio Production 1
+  features {}
+}
+
+provider "azurerm" {
+  alias           = "apvs"
+  tenant_id       = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+  subscription_id = "19c0e044-6167-4048-a817-7ac7b4323f06" # APVS Production
   features {}
 }


### PR DESCRIPTION
This update is in response to Ewa's comments in [DSO-819](https://dsdmoj.atlassian.net/browse/DSO-819). The resources have already been imported into Terraform state.