### PR TITLE
DSO-902: decom of unused onr and oasys-preprod AppGw.

### DIFF
--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -101,22 +101,6 @@ resource "azurerm_dns_cname_record" "bridge_onr" {
   ttl                 = 300
 }
 
-resource "azurerm_dns_cname_record" "bridge_pp_oasys" {
-  name                = "bridge-pp-oasys"
-  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "oasys-preprod.uksouth.cloudapp.azure.com"
-  ttl                 = 300
-}
-
-resource "azurerm_dns_cname_record" "bridge_pp_onr" {
-  name                = "bridge-pp-onr"
-  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "onr-preprod.uksouth.cloudapp.azure.com"
-  ttl                 = 300
-}
-
 resource "azurerm_dns_cname_record" "bridge_practice_oasys" {
   name                = "bridge-practice.oasys"
   zone_name           = azurerm_dns_zone.az_justice_gov_uk.name


### PR DESCRIPTION
The oasys-preprod and onr-preprod Application Gateways are not used. They were built relatively recently to help validate certificate renewal process but are not actively used otherwise. Since the renewal process is working well now, and we have replacement Application Gateway V2s in place, we can decommission these as part of the AppGw V2 migration work.

This PR removes the associated AppGateway DNS entries for oasys-preprod and onr-preprod.  There is zero traffic on these AppGateways since we removed the prometheus monitoring, so it's safe to remove these.