### PR TITLE
Feature/dso 901/migrate cafmpreprod to appgw v2

### DIFF
--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -132,7 +132,7 @@ resource "azurerm_dns_cname_record" "cafm_preprod" {
   name                = "cafm-preprod"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-preprod-ukwest-appgw1-moj.ukwest.cloudapp.azure.com"
+  record              = "hmpps-preprod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 
@@ -148,7 +148,7 @@ resource "azurerm_dns_cname_record" "cafmpmg_preprod" {
   name                = "cafmpmg-preprod"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-preprod-ukwest-appgw1-moj.ukwest.cloudapp.azure.com"
+  record              = "hmpps-preprod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 

--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -132,7 +132,7 @@ resource "azurerm_dns_cname_record" "cafm_preprod" {
   name                = "cafm-preprod"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "cafm-preprod.ukwest.cloudapp.azure.com"
+  record              = "hmpps-preprod-ukwest-appgw1-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 
@@ -148,7 +148,7 @@ resource "azurerm_dns_cname_record" "cafmpmg_preprod" {
   name                = "cafmpmg-preprod"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "cafm-preprod.ukwest.cloudapp.azure.com"
+  record              = "hmpps-preprod-ukwest-appgw1-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 


### PR DESCRIPTION
Part of AppGw V2 project to consolidate AppGateways.  Glenn has confirmed external endpoints (i.e. via cafm-preprod/cafm-prod AppGateways) are barely used and this is also confirmed by Log Analytics.  Migrate the endpoint across to the new AppGw V2 .

The URLs have been tested on the new AppGateway (using Firefox with socks proxy).  IPs allowed to cafm-preprod endpoint are also allowed on the new Appgateway.

This is a simple DNS change.  Roll back is to revert this change.