### PR TITLE
DSO-688 disable ip masking for app insights

### DIFF
--- a/shared/modules/azure-app-service/main.tf
+++ b/shared/modules/azure-app-service/main.tf
@@ -146,6 +146,7 @@ resource "azurerm_application_insights" "insights" {
   retention_in_days   = 90
   sampling_percentage = var.sampling_percentage
   tags                = var.tags
+  disable_ip_masking  = true
   lifecycle {
     ignore_changes = [
       application_type


### PR DESCRIPTION
app insights is the main tool used for app services to analyse requests.
We could ship the logs to LA workspace but the app insights are already implemented
we just need to see the IPs which are by default masked.

This is needed to analyse client ip addresses so we can restrict access to all app services
going forward.