### PR TITLE
DSO-978: rework appgwV2 internal zones.  

### DIFF
--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -85,14 +85,6 @@ resource "azurerm_dns_ns_record" "cafm_ns_record" {
   ttl                 = "3600"
 }
 
-resource "azurerm_dns_a_record" "reporting_lsast_nomis" {
-  name                = "reporting.lsast-nomis"
-  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
-  resource_group_name = azurerm_resource_group.group.name
-  records             = ["10.40.44.198"]
-  ttl                 = 300
-}
-
 resource "azurerm_dns_cname_record" "bridge_oasys" {
   name                = "bridge-oasys"
   zone_name           = azurerm_dns_zone.az_justice_gov_uk.name

--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -56,6 +56,35 @@ resource "azurerm_dns_cname_record" "user_guide" {
   zone_name           = azurerm_dns_zone.studio_hosting.name
 }
 
+resource "azurerm_dns_ns_record" "nomis_ns_record" {
+  name                = "nomis"
+  records             = ["ns1-08.azure-dns.com.", "ns2-08.azure-dns.net.", "ns3-08.azure-dns.org.", "ns4-08.azure-dns.info."]
+  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
+  resource_group_name = azurerm_resource_group.group.name
+  ttl                 = "3600"
+}
+resource "azurerm_dns_ns_record" "oasys_ns_record" {
+  name                = "oasys"
+  records             = ["ns1-08.azure-dns.com.", "ns2-08.azure-dns.net.", "ns3-08.azure-dns.org.", "ns4-08.azure-dns.info."]
+  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
+  resource_group_name = azurerm_resource_group.group.name
+  ttl                 = "3600"
+}
+resource "azurerm_dns_ns_record" "csr_ns_record" {
+  name                = "csr"
+  records             = ["ns1-08.azure-dns.com.", "ns2-08.azure-dns.net.", "ns3-08.azure-dns.org.", "ns4-08.azure-dns.info."]
+  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
+  resource_group_name = azurerm_resource_group.group.name
+  ttl                 = "3600"
+}
+resource "azurerm_dns_ns_record" "cafm_ns_record" {
+  name                = "cafm"
+  records             = ["ns1-08.azure-dns.com.", "ns2-08.azure-dns.net.", "ns3-08.azure-dns.org.", "ns4-08.azure-dns.info."]
+  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
+  resource_group_name = azurerm_resource_group.group.name
+  ttl                 = "3600"
+}
+
 resource "azurerm_dns_a_record" "reporting_lsast_nomis" {
   name                = "reporting.lsast-nomis"
   zone_name           = azurerm_dns_zone.az_justice_gov_uk.name


### PR DESCRIPTION
Following discussion with Matt White, we've agreed to update the new AppGateway internal URLs to use .az.justice.gov.uk domains rather than .service.justice.gov.uk. This should avoid DXC DNS changes with a bit of luck!

For example:
Existing URL: mis.nomis.az.justice.gov.uk
New AppGwV2 URL (for testing): mis.prod.nomis.az.justice.gov.uk
Previous AppGwV2 URL: mis.service.justice.gov.uk.

Also removing reporting-lsast which shouldn't be in this.  I had removed manually but forgot was managed by terraform....

Change:
Adding nomis, oasys, csr and cafm NS records in az.justice.gov.uk.  These zones are in NOMSProduction1 and are managed by hmpps-fixngo-terraform repo, but the parent zone is here.