### PR TITLE
Feature/dso 901/migrate cafm prod to appgw v2

### DIFF
--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -70,20 +70,6 @@ resource "azurerm_dns_ns_record" "oasys_ns_record" {
   resource_group_name = azurerm_resource_group.group.name
   ttl                 = "3600"
 }
-resource "azurerm_dns_ns_record" "csr_ns_record" {
-  name                = "csr"
-  records             = ["ns1-06.azure-dns.com.", "ns2-06.azure-dns.net.", "ns3-06.azure-dns.org.", "ns4-06.azure-dns.info."]
-  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
-  resource_group_name = azurerm_resource_group.group.name
-  ttl                 = "3600"
-}
-resource "azurerm_dns_ns_record" "cafm_ns_record" {
-  name                = "cafm"
-  records             = ["ns1-05.azure-dns.com.", "ns2-05.azure-dns.net.", "ns3-05.azure-dns.org.", "ns4-05.azure-dns.info."]
-  zone_name           = azurerm_dns_zone.az_justice_gov_uk.name
-  resource_group_name = azurerm_resource_group.group.name
-  ttl                 = "3600"
-}
 
 resource "azurerm_dns_cname_record" "bridge_oasys" {
   name                = "bridge-oasys"

--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -145,7 +145,7 @@ resource "azurerm_dns_cname_record" "cafm" {
   name                = "cafm"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "cafm-prod.ukwest.cloudapp.azure.com"
+  record              = "hmpps-prod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 
@@ -161,7 +161,7 @@ resource "azurerm_dns_cname_record" "cafmpmg" {
   name                = "cafmpmg"
   zone_name           = azurerm_dns_zone.service-hmpps.name
   resource_group_name = azurerm_resource_group.group.name
-  record              = "cafm-prod.ukwest.cloudapp.azure.com"
+  record              = "hmpps-prod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
   ttl                 = 300
 }
 

--- a/webops/prod/dns.tf
+++ b/webops/prod/dns.tf
@@ -141,38 +141,6 @@ resource "azurerm_dns_a_record" "aap" {
   ttl                 = 300
 }
 
-resource "azurerm_dns_cname_record" "cafm" {
-  name                = "cafm"
-  zone_name           = azurerm_dns_zone.service-hmpps.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-prod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
-  ttl                 = 300
-}
-
-resource "azurerm_dns_cname_record" "cafm_preprod" {
-  name                = "cafm-preprod"
-  zone_name           = azurerm_dns_zone.service-hmpps.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-preprod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
-  ttl                 = 300
-}
-
-resource "azurerm_dns_cname_record" "cafmpmg" {
-  name                = "cafmpmg"
-  zone_name           = azurerm_dns_zone.service-hmpps.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-prod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
-  ttl                 = 300
-}
-
-resource "azurerm_dns_cname_record" "cafmpmg_preprod" {
-  name                = "cafmpmg-preprod"
-  zone_name           = azurerm_dns_zone.service-hmpps.name
-  resource_group_name = azurerm_resource_group.group.name
-  record              = "hmpps-preprod-ukwest-appgw2-moj.ukwest.cloudapp.azure.com"
-  ttl                 = 300
-}
-
 resource "azurerm_dns_cname_record" "dso_monitoring_prod" {
   name                = "dso-monitoring-prod"
   zone_name           = azurerm_dns_zone.service-hmpps.name


### PR DESCRIPTION
Glenn Barber confirmed the CAFM external links, i.e. cafm-prod and cafm-preprod AppGateways, are completely unused. This is also supported by the AppGw logs. We've agreed to remove them.

This change removes the DNS entries so they aren't left dangling.  Note the monitoring is already removed.