### PR TITLE
DSO-881 make https required on HPA prod

### DIFF
--- a/iis/prod/terraform.tfvars
+++ b/iis/prod/terraform.tfvars
@@ -23,7 +23,7 @@ default_documents = [
   "hostingstart.html"
 ]
 has_storage = true
-https_only  = false
+https_only  = true
 key_vault_secrets = [
   "signon-client-id",
   "signon-client-secret",


### PR DESCRIPTION
From looking at https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/140643751/Historical+Prisoner+Application

It indicates https is the valid way of accessing, which makes sense.

Confirmed with service owner they are happy with change. Should not affect
users if they are already accessing with https.